### PR TITLE
Add optional example building flags to everest-complete.yaml

### DIFF
--- a/everest-complete.yaml
+++ b/everest-complete.yaml
@@ -26,12 +26,16 @@ liblog:
 libmodbus:
   git: git@github.com:EVerest/libmodbus.git
   git_tag: main
+  options:
+  - BUILD_EXAMPLES OFF
 libocpp:
   git: git@github.com:EVerest/libocpp.git
   git_tag: main
 libsunspec:
   git: git@github.com:EVerest/libsunspec.git
   git_tag: main
+  options:
+  - BUILD_EXAMPLES OFF
 libtimer:
   git: git@github.com:EVerest/libtimer.git
   git_tag: main


### PR DESCRIPTION
libsunspec and libmodbus now have cmake options to build the examples or not. this is just to reflect that into the building process, setting the default as not building them.