### PR TITLE
Change the way edm CMake mode handles branches of local dependencies.

### DIFF
--- a/dependency_manager/setup.cfg
+++ b/dependency_manager/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = edm_tool
-version = 0.1.4
+version = 0.2.0
 
 [options]
 packages = edm_tool

--- a/dependency_manager/setup.py
+++ b/dependency_manager/setup.py
@@ -13,7 +13,7 @@ long_description = (here / 'README.md').read_text(encoding='utf-8')
 
 setup(
     name='edm_tool',
-    version='0.1.4',
+    version='0.2.0',
     description='A simple dependency manager',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/dependency_manager/src/edm_tool/edm.py
+++ b/dependency_manager/src/edm_tool/edm.py
@@ -599,7 +599,7 @@ class EDM:
                     git_tag = dependencies[name]["git_tag"]
                 if entry is not None and "git_tag" in entry:
                     git_tag = entry["git_tag"]
-                checkout.append(checkout_local_dependency(name, dependencies[name]["git"], git_tag, checkout_dir))
+                checkout.append(checkout_local_dependency(name, dependencies[name]["git"], git_tag, checkout_dir, True))
 
         return checkout
 
@@ -624,11 +624,11 @@ class EDM:
             out.write(render)
 
 
-def checkout_local_dependency(name: str, git: str, git_tag: str, checkout_dir: Path) -> dict:
+def checkout_local_dependency(name: str, git: str, git_tag: str, checkout_dir: Path, keep_branch=False) -> dict:
     """
     Clone local dependency into checkout_dir.
 
-    If the directory already exists only switch branches if the git repo is not dirty.
+    If the directory already exists only switch branches if the git repo is not dirty or keep_branch is True
     """
     def clone_dependency_repo(git: str, git_tag: str, checkout_dir: Path) -> None:
         """Clone given git repository at the given git_tag into checkout_dir."""
@@ -656,6 +656,8 @@ def checkout_local_dependency(name: str, git: str, git_tag: str, checkout_dir: P
         # check if git is dirty
         if GitInfo.is_dirty(checkout_dir):
             log.debug("    Repo is dirty, nothing will be done to this repo.")
+        elif keep_branch:
+            log.debug("    Keeping currently checked out branch.")
         else:
             # if the repo is clean we can safely switch branches
             if git_tag is not None:
@@ -753,7 +755,7 @@ def get_parser() -> argparse.ArgumentParser:
     """Return the argument parser containign all command line options."""
     parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter,
                                      description="Everest Dependency Manager")
-    parser.add_argument('--version', action='version', version='%(prog)s 0.1.4')
+    parser.add_argument('--version', action='version', version='%(prog)s 0.2.0')
     parser.add_argument(
         "--workspace", metavar='WORKSPACE',
         help="Directory in which source code repositories that are explicity requested are checked out.",

--- a/dependency_manager/src/edm_tool/edm.py
+++ b/dependency_manager/src/edm_tool/edm.py
@@ -628,7 +628,7 @@ def checkout_local_dependency(name: str, git: str, git_tag: str, checkout_dir: P
     """
     Clone local dependency into checkout_dir.
 
-    If the directory already exists only switch branches if the git repo is not dirty or keep_branch is True
+    If the directory already exists only switch branches if the git repo is not dirty or keep_branch is False
     """
     def clone_dependency_repo(git: str, git_tag: str, checkout_dir: Path) -> None:
         """Clone given git repository at the given git_tag into checkout_dir."""


### PR DESCRIPTION
Up until now edm always tried to checkout the branch specified in the dependency for local dependencies in the workspace unless the repository has uncommited changes.
This leads to very surprising behavior, you could start working on a feature in a local dependency in the workspace and everything just worked as expected - until you committed your changes to a new branch.
If this lead to the new branch beeing "clean" (no uncommitted changes present) edm would just change the branch of the local dependency back to the original branch (usually main).
This change adresses this issue by never changing a branch in CMake mode if the local dependency already exists.

Signed-off-by: Kai-Uwe Hermann <kai-uwe.hermann@pionix.de>