### PR TITLE
Add support for prevent_install option in dependencies.yaml

### DIFF
--- a/dependency_manager/setup.cfg
+++ b/dependency_manager/setup.cfg
@@ -1,9 +1,37 @@
 [metadata]
 name = edm_tool
-version = 0.2.1
+version = attr: edm_tool.__version__
+description= A simple dependency manager
+long_description = file: README.md
+long_description_content_type= text/markdown
+url= https://github.com/EVerest/everest-dev-environment
+author = Kai-Uwe Hermann
+author_email = kai-uwe.hermann@pionix.de
+classifiers =
+    Development Status :: 3 - Alpha
+    Intended Audience :: Developers
+    Topic :: Software Development :: Build Tools
+    License :: OSI Approved :: Apache Software License
 
 [options]
 packages = edm_tool
+package_dir =
+    = src
+python_requires = >=3.6
+install_requires =
+    Jinja2>=2.11
+    PyYAML>=5.3
+
+[options.entry_points]
+console_scripts =
+    edm = edm_tool:main
+
+[options.package_data]
+edm_tool =
+    templates/cpm.jinja
+    cmake/CPM.cmake
+    cmake/EDMConfig.cmake
+    edm-completion.bash
 
 [pycodestyle]
 max-line-length = 120

--- a/dependency_manager/setup.py
+++ b/dependency_manager/setup.py
@@ -1,42 +1,9 @@
-#
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
-#
 """Everest Dependency Manager."""
 
 from setuptools import setup, find_packages
-import pathlib
-
-here = pathlib.Path(__file__).parent.resolve()
-
-long_description = (here / 'README.md').read_text(encoding='utf-8')
 
 setup(
-    name='edm_tool',
-    version='0.2.1',
-    description='A simple dependency manager',
-    long_description=long_description,
-    long_description_content_type='text/markdown',
-    url='https://github.com/EVerest/everest-dev-environment',
-    author='Kai-Uwe Hermann',
-    author_email='kai-uwe.hermann@pionix.de',
-    classifiers=[
-        'Development Status :: 3 - Alpha',
-        'Intended Audience :: Developers',
-        'Topic :: Software Development :: Build Tools',
-        'License :: OSI Approved :: Apache Software License',
-    ],
-    package_dir={'': 'src'},
-    packages=find_packages(where='src'),
-    python_requires='>=3.6, <4',
-    install_requires=['Jinja2>=2.11',
-                      'PyYAML>=5.3'],
-    package_data={
-        'edm_tool': ['templates/cpm.jinja', 'cmake/CPM.cmake', 'cmake/EDMConfig.cmake', 'edm-completion.bash'],
-    },
-    entry_points={
-        'console_scripts': [
-            'edm=edm_tool:main',
-        ],
-    },
+    # see setup.cfg
 )

--- a/dependency_manager/src/edm_tool/__init__.py
+++ b/dependency_manager/src/edm_tool/__init__.py
@@ -4,11 +4,12 @@
 #
 """Everest Dependency Manager."""
 from edm_tool import edm
+__version__ = "0.2.2"
 
 
 def get_parser():
     """Return the command line parser."""
-    return edm.get_parser()
+    return edm.get_parser(__version__)
 
 
 def main():

--- a/dependency_manager/src/edm_tool/edm.py
+++ b/dependency_manager/src/edm_tool/edm.py
@@ -751,11 +751,11 @@ def create_vscode_workspace(workspace_path: Path, workspace_checkout: dict):
         json.dump(content, ws_file, indent="\t")
 
 
-def get_parser() -> argparse.ArgumentParser:
+def get_parser(version) -> argparse.ArgumentParser:
     """Return the argument parser containign all command line options."""
     parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter,
                                      description="Everest Dependency Manager")
-    parser.add_argument('--version', action='version', version='%(prog)s 0.2.1')
+    parser.add_argument('--version', action='version', version=f'%(prog)s {version}')
     parser.add_argument(
         "--workspace", metavar='WORKSPACE',
         help="Directory in which source code repositories that are explicity requested are checked out.",

--- a/dependency_manager/src/edm_tool/templates/cpm.jinja
+++ b/dependency_manager/src/edm_tool/templates/cpm.jinja
@@ -14,6 +14,9 @@ CPMAddPackage(
     OPTIONS
         {{value["options"]|quote|join(" ")}}
 {% endif %}
+{% if "prevent_install" in value and value["prevent_install"] %}
+    EXCLUDE_FROM_ALL YES
+{% endif %}
 )
 {% else %}
 find_package(


### PR DESCRIPTION
When prevent_install is set to true the EXCLUDE_FROM_ALL option of CPM is set to YES, this prevents this dependency from installing targets which can be useful in some cases where the dependency does not provide an option to disable installing of targets.
https://github.com/cpm-cmake/CPM.cmake/releases/tag/v0.29.0