### PR TITLE
Removed obsolete open-plc-utils repo in EVerest complete config

### DIFF
--- a/everest-complete.yaml
+++ b/everest-complete.yaml
@@ -44,6 +44,3 @@ libtimer:
   git_tag: main
   options:
   - BUILD_EXAMPLES OFF
-open-plc-utils:
-  git: git@github.com:EVerest/ext-open-plc-utils.git
-  git_tag: master


### PR DESCRIPTION
Signed-off-by: Kai-Uwe Hermann <kai-uwe.hermann@pionix.de>