### PR TITLE
Simplify workspace management

### DIFF
--- a/dependency_manager/src/edm_tool/__init__.py
+++ b/dependency_manager/src/edm_tool/__init__.py
@@ -4,7 +4,7 @@
 #
 """Everest Dependency Manager."""
 from edm_tool import edm
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 
 def get_parser():

--- a/dependency_manager/src/edm_tool/templates/cpm.jinja
+++ b/dependency_manager/src/edm_tool/templates/cpm.jinja
@@ -1,3 +1,4 @@
+set(ENV{EVEREST_EDM_WORKSPACE} {{ workspace["workspace"] }})
 set(CPM_USE_NAMED_CACHE_DIRECTORIES ON)
 {% for dep in checkout %}
 set(CPM_{{ dep["name"] }}_SOURCE "{{ dep["path"] }}")


### PR DESCRIPTION
workspace.yaml files are not needed anymore, from now on it is assumed that the parent directory is the workspace

speedup of tag and rev detection for cached dependencies