### PR TITLE
Support branches in the release parameter of edm init

### DIFF
--- a/dependency_manager/src/edm_tool/__init__.py
+++ b/dependency_manager/src/edm_tool/__init__.py
@@ -4,7 +4,7 @@
 #
 """Everest Dependency Manager."""
 from edm_tool import edm
-__version__ = "0.5.2"
+__version__ = "0.5.3"
 
 
 def get_parser():


### PR DESCRIPTION
Things like "edm init main" did not work as expected.
Fixed checking out dependencies that were specified with revs instead of tags