### PR TITLE
Don't use required parameter in add_subparsers

### DIFF
--- a/dependency_manager/setup.cfg
+++ b/dependency_manager/setup.cfg
@@ -17,7 +17,7 @@ classifiers =
 packages = edm_tool
 package_dir =
     = src
-python_requires = >=3.7
+python_requires = >=3.6
 install_requires =
     Jinja2>=2.11
     PyYAML>=5.3

--- a/dependency_manager/src/edm_tool/__init__.py
+++ b/dependency_manager/src/edm_tool/__init__.py
@@ -4,7 +4,7 @@
 #
 """Everest Dependency Manager."""
 from edm_tool import edm
-__version__ = "0.5.2"
+__version__ = "0.5.3"
 
 
 def get_parser():

--- a/dependency_manager/src/edm_tool/edm.py
+++ b/dependency_manager/src/edm_tool/edm.py
@@ -1385,7 +1385,7 @@ def get_parser(version) -> argparse.ArgumentParser:
     # parser.add_argument("--interactive", action='store_true',
     #                     help="Interactively ask which repositories should be checked out.")
 
-    subparsers = parser.add_subparsers(help='available commands', required=False)
+    subparsers = parser.add_subparsers(help='available commands')
 
     init_parser = subparsers.add_parser('init', add_help=True)
     init_parser.add_argument(
@@ -1417,7 +1417,7 @@ def get_parser(version) -> argparse.ArgumentParser:
         nargs=1)
 
     git_parser = subparsers.add_parser('git', add_help=True)
-    git_subparsers = git_parser.add_subparsers(help='available git commands', required=False)
+    git_subparsers = git_parser.add_subparsers(help='available git commands')
 
     git_info_parser = git_subparsers.add_parser('info', add_help=True)
     git_info_parser.add_argument(


### PR DESCRIPTION
This drops the required python version back to to 3.6