### PR TITLE
Deleted parameter register-cmake-module

### DIFF
--- a/dependency_manager/README.md
+++ b/dependency_manager/README.md
@@ -68,22 +68,12 @@ If you installed **edm** using the guide above they were already installed autom
 - Jinja2 >= 3.0
 - PyYAML >= 5.4
 
-## Setting up CMake integration
-To use the **EDM** CMake module you **must** register it in the [CMake package registry](https://gitlab.kitware.com/cmake/community/-/wikis/doc/tutorials/Package-Registry#user).
-You can use the following command to achieve this:
-
-```bash
-edm --register-cmake-module
-```
-This will create a file at *~/.cmake/packages/EDM/edm* that points to the directory in which the **EDM** CMake module has been installed.
-You probably have to do this only once after the initial installation, but be advised that this might have to be done again if you reinstall **edm** with a different version of Python.
-
 ## Setting up a workspace
 A sample workspace config, [everest-complete.yaml](../everest-complete.yaml), for the EVerest project is provided in the root directory of this repository.
 You can set up this workspace with the following command.
 
 ```bash
-edm --register-cmake-module --config ../everest-complete.yaml --workspace ~/checkout/everest-workspace
+edm --config ../everest-complete.yaml --workspace ~/checkout/everest-workspace
 ```
 
 ## Updating a workspace

--- a/dependency_manager/README.md
+++ b/dependency_manager/README.md
@@ -34,7 +34,7 @@ edm --config ../everest-complete.yaml --workspace ~/checkout/everest-workspace
 ```
 
 The last command registers the [**EDM** CMake module](#setting-up-cmake-integration) and creates a workspace in the *~/checkout/everest-workspace* directory from [a config that is shipped with this repository](../everest-complete.yaml).
-The workspace will have the following structure containing all current dependencies for everest:
+The workspace will have the following structure containing all current dependencies for EVerest:
 ```bash
 everest-workspace/
 ├── everest-core
@@ -77,13 +77,15 @@ edm --config ../everest-complete.yaml --workspace ~/checkout/everest-workspace
 ```
 
 ## Updating a workspace
-To update a workspace you can edit the *workspace-config.yaml* file in the root of the workspace. You can then use the following command to apply these changes.
+To update a workspace you can edit the *workspace-config.yaml* file in the root of the workspace. You can then use the following command to apply these changes:
+
 ```bash
-edm --workspace ~/checkout/everest-workspace --update
+edm init --workspace ~/checkout/everest-workspace
 ```
-If you are currently in the *everest-workspace* directory the following command has the same effect.
+If you are currently in the *everest-workspace* directory the following command has the same effect:
+
 ```bash
-edm --update
+edm init
 ```
 
 Be advised that even if you remove a repository from the config file it WILL NOT be deleted from the workspace.
@@ -91,6 +93,7 @@ Be advised that even if you remove a repository from the config file it WILL NOT
 An attempt will be made to switch branches to the ones specified in the config, however this will be aborted if the repository is *dirty*.
 
 Repositories also WILL NOT be pulled, you should check the state of your repositories afterwards with the commands described in [Git information at a glance](#git-information-at-a-glance)
+
 ## Using the EDM CMake module and dependencies.yaml
 To use **edm** from CMake you have to add the following line to the top-level *CMakeLists.txt* file in the respective source repository:
 ```cmake


### PR DESCRIPTION
@hikinggrass I deleted the register-cmake-module parameter here. Two questions before I create a PR:

1. Do we need info about the implicit registration of edm-registration in the docu? Is that somehow relevant during the development process?
2. The --update parameter seems also to be deleted from edm. I would delete the section about updating here also. Is the --git-pull parameter a 1:1 replacement for --update?