### PR TITLE
Use versionsort.suffix when listing tag names (fixes #39)

### DIFF
--- a/dependency_manager/src/edm_tool/edm.py
+++ b/dependency_manager/src/edm_tool/edm.py
@@ -326,7 +326,7 @@ class GitInfo:
         """Return the remote tags of the repo at path, or an empty list."""
         remote_tags = []
         try:
-            result = subprocess.run(["git", "ls-remote", "--tags", "--sort=-v:refname", "--refs", "--quiet", remote_url],
+            result = subprocess.run(["git", "-c", "versionsort.suffix=-", "ls-remote", "--tags", "--sort=-v:refname", "--refs", "--quiet", remote_url],
                                     stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
             result_list = result.stdout.decode("utf-8").split("\n")
             for entry in result_list:


### PR DESCRIPTION
Tag names including suffixes like -rcXY or similar needs to be sorted before the final release/tag.

This is what git's versionsort.suffix is intended for, so let's use it.

Let's use a wide matching here, so that -rcX, -pre, -alpha etc. are covered - just to be on the safe side.