### PR TITLE
Add Bazel dependencies generator

### DIFF
--- a/dependency_manager/src/edm_tool/__init__.py
+++ b/dependency_manager/src/edm_tool/__init__.py
@@ -4,7 +4,7 @@
 #
 """Everest Dependency Manager."""
 from edm_tool import edm
-__version__ = "0.6.1"
+__version__ = "0.6.2"
 
 
 def get_parser():

--- a/dependency_manager/src/edm_tool/bazel.py
+++ b/dependency_manager/src/edm_tool/bazel.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+import yaml
+from argparse import ArgumentParser
+from pathlib import Path
+import sys
+
+def generate_deps(args):
+    deps = yaml.safe_load(open(args.dependencies_yaml, 'r'))
+    print("Buid files: ", args.build_file, file=sys.stderr)
+    if args.build_file:
+        build_files = dict((f.split(":")[1], f) for f in args.build_file)
+    else:
+        build_files = {}
+
+    print('load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")')
+    print('load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")')
+    print()
+    print()
+
+    print("def edm_deps():")
+
+    for name, desc in deps.items():
+        repo = desc['git']
+        tag = desc["git_tag"]
+        commit = "None"
+
+        # Check that tag is hexadecimal 40-character string
+        if len(tag) == 40 and all(c in "0123456789abcdef" for c in tag.lower()):
+            tag, commit = "None", f'"{tag}"'
+        else:
+            tag, commit = f'"{tag}"', "None"
+        
+        build_file_name = f"BUILD.{name}.bazel"
+        if build_file_name in build_files:
+            build_file_label = build_files[build_file_name]
+            build_file = f'"{build_file_label}"'
+        else:
+            build_file = "None"
+
+        print(
+            f"""
+    maybe(
+        git_repository,
+        name = "{name}",
+        remote = "{repo}",
+        tag = {tag},
+        commit = {commit},
+        build_file = {build_file},
+    )
+"""
+        )

--- a/dependency_manager/src/edm_tool/bazel.py
+++ b/dependency_manager/src/edm_tool/bazel.py
@@ -1,11 +1,13 @@
-#!/usr/bin/env python3
-import yaml
-from argparse import ArgumentParser
-from pathlib import Path
+"Bazel related functions for edm_tool."
 import sys
 
+import yaml
+
+
 def generate_deps(args):
-    deps = yaml.safe_load(open(args.dependencies_yaml, 'r'))
+    "Parse the dependencies.yaml and print content of *.bzl file to stdout."
+    with open(args.dependencies_yaml, 'r', encoding='utf-8') as f:
+        deps = yaml.safe_load(f)
     print("Buid files: ", args.build_file, file=sys.stderr)
     if args.build_file:
         build_files = dict((f.split(":")[1], f) for f in args.build_file)
@@ -13,7 +15,9 @@ def generate_deps(args):
         build_files = {}
 
     print('load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")')
-    print('load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")')
+    print(
+        'load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")'
+    )
     print()
     print()
 
@@ -29,7 +33,7 @@ def generate_deps(args):
             tag, commit = "None", f'"{tag}"'
         else:
             tag, commit = f'"{tag}"', "None"
-        
+
         build_file_name = f"BUILD.{name}.bazel"
         if build_file_name in build_files:
             build_file_label = build_files[build_file_name]

--- a/dependency_manager/src/edm_tool/bazel.py
+++ b/dependency_manager/src/edm_tool/bazel.py
@@ -1,6 +1,4 @@
 "Bazel related functions for edm_tool."
-import sys
-
 import yaml
 
 

--- a/dependency_manager/src/edm_tool/edm.py
+++ b/dependency_manager/src/edm_tool/edm.py
@@ -19,6 +19,7 @@ import multiprocessing
 import requests
 import re
 import datetime
+import edm_tool.bazel as bazel
 
 
 log = logging.getLogger("edm")
@@ -1611,6 +1612,21 @@ def get_parser(version) -> argparse.ArgumentParser:
         help="Path to release.json file",
         nargs="?",
         default="release.json")
+    
+    bazel_parser = subparsers.add_parser(
+        'bazel',
+        description="""Convert dependencies.yaml file into a file that can be used in Bazel workspace.""",
+        add_help=True)
+    bazel_parser.set_defaults(action_handler=bazel.generate_deps)
+    bazel_parser.add_argument(
+        "dependencies_yaml",
+        type=Path,
+        help="Path to dependencies.yaml")
+    bazel_parser.add_argument(
+        "-b", "--build-file",
+        type=str,
+        action="append",
+        required=False)
 
     parser.set_defaults(action_handler=main_handler)
 

--- a/dependency_manager/src/edm_tool/edm.py
+++ b/dependency_manager/src/edm_tool/edm.py
@@ -19,6 +19,7 @@ import multiprocessing
 import requests
 import re
 import datetime
+
 from edm_tool import bazel
 
 
@@ -1613,8 +1614,8 @@ def get_parser(version) -> argparse.ArgumentParser:
         nargs="?",
         default="release.json")
     bazel_parser = subparsers.add_parser(
-        'bazel',
-        description="""Convert dependencies.yaml file into a file that can be used in Bazel workspace.""",
+        "bazel",
+        description="Convert dependencies.yaml file into a file that can be used in Bazel workspace.",
         add_help=True)
     bazel_parser.set_defaults(action_handler=bazel.generate_deps)
     bazel_parser.add_argument(
@@ -1625,6 +1626,11 @@ def get_parser(version) -> argparse.ArgumentParser:
         "-b", "--build-file",
         type=str,
         action="append",
+        help="Bazel-style label for the build files into the deppendencies." +
+            "The format should be `@<workspace>//<path>:BUILD.<dependency-name>.bazel`." + 
+            "<dependency-name> should correspond to the name of the dependency in " +
+            "the dependencies.yaml file. This option can be used multiple times." + 
+            "If not provided, Bazel will search for BUILD file in the repo itself.",
         required=False)
 
     parser.set_defaults(action_handler=main_handler)

--- a/dependency_manager/src/edm_tool/edm.py
+++ b/dependency_manager/src/edm_tool/edm.py
@@ -19,7 +19,7 @@ import multiprocessing
 import requests
 import re
 import datetime
-import edm_tool.bazel as bazel
+from edm_tool import bazel
 
 
 log = logging.getLogger("edm")
@@ -1612,7 +1612,6 @@ def get_parser(version) -> argparse.ArgumentParser:
         help="Path to release.json file",
         nargs="?",
         default="release.json")
-    
     bazel_parser = subparsers.add_parser(
         'bazel',
         description="""Convert dependencies.yaml file into a file that can be used in Bazel workspace.""",

--- a/dependency_manager/src/edm_tool/edm.py
+++ b/dependency_manager/src/edm_tool/edm.py
@@ -1626,11 +1626,11 @@ def get_parser(version) -> argparse.ArgumentParser:
         "-b", "--build-file",
         type=str,
         action="append",
-        help="Bazel-style label for the build files into the deppendencies." +
-            "The format should be `@<workspace>//<path>:BUILD.<dependency-name>.bazel`." + 
-            "<dependency-name> should correspond to the name of the dependency in " +
-            "the dependencies.yaml file. This option can be used multiple times." + 
-            "If not provided, Bazel will search for BUILD file in the repo itself.",
+        help="Bazel-style label for the build files into the deppendencies. " +
+             "The format should be `@<workspace>//<path>:BUILD.<dependency-name>.bazel`." + 
+             "<dependency-name> should correspond to the name of the dependency in " +
+             "the dependencies.yaml file. This option can be used multiple times." + 
+             "If not provided, Bazel will search for BUILD file in the repo itself.",
         required=False)
 
     parser.set_defaults(action_handler=main_handler)


### PR DESCRIPTION
Previously the the dependencies for Bazel build needed to be generated and committed to the everest-core. Which was an extra step for every change in the dependencies.yaml.

By moving the dependencies generator to the external repository we achieve that Bazel can use the `edm` tool to parse the dependencies.yaml. For the user, the bezel consumes dependencies information directly from the dependencies.yaml

Here is the PR for the corresponding changes in the everest-core: https://github.com/EVerest/everest-core/pull/699