### PR TITLE
Pin node-red dependencies in nodered Dockerfile

### DIFF
--- a/docker/images/nodered/Dockerfile
+++ b/docker/images/nodered/Dockerfile
@@ -1,5 +1,5 @@
 FROM nodered/node-red:2.2.3
 RUN npm install node-red-dashboard
 RUN npm install node-red-contrib-ui-actions
-RUN npm install node-red-node-ui-table
+RUN npm install node-red-node-ui-table@0.4.3
 RUN npm install node-red-contrib-ui-level

--- a/docker/images/nodered/Dockerfile
+++ b/docker/images/nodered/Dockerfile
@@ -1,5 +1,5 @@
 FROM nodered/node-red:2.2.3
-RUN npm install node-red-dashboard
-RUN npm install node-red-contrib-ui-actions
+RUN npm install node-red-dashboard@3.6.5
+RUN npm install node-red-contrib-ui-actions@0.1.8
 RUN npm install node-red-node-ui-table@0.4.3
-RUN npm install node-red-contrib-ui-level
+RUN npm install node-red-contrib-ui-level@0.1.46


### PR DESCRIPTION
This fixes a new issue which node-red-node-ui-table 0.4.4 added which causes this warning and the UI no longer loads:
    
    Node module cannot be loaded on this version. Requires: >=3.0.0

Fixes #49