### PR TITLE
update get_git_repo_info to avoid KeyError exception

### DIFF
--- a/dependency_manager/src/edm_tool/__init__.py
+++ b/dependency_manager/src/edm_tool/__init__.py
@@ -4,7 +4,8 @@
 #
 """Everest Dependency Manager."""
 from edm_tool import edm
-__version__ = "0.6.2"
+
+__version__ = "0.7.0"
 
 
 def get_parser():

--- a/dependency_manager/src/edm_tool/__init__.py
+++ b/dependency_manager/src/edm_tool/__init__.py
@@ -5,7 +5,7 @@
 """Everest Dependency Manager."""
 from edm_tool import edm
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 
 
 def get_parser():

--- a/dependency_manager/src/edm_tool/edm.py
+++ b/dependency_manager/src/edm_tool/edm.py
@@ -411,10 +411,22 @@ class GitInfo:
         """
         Return useful information about a repository a the given path.
 
-        TODO: return type should be a well defined object
-        Returns an empty dictionary if the path is no git repo
+        Returns a default dictionary if the path is no git repo
         """
-        repo_info = {'is_repo': False}
+        repo_info = {
+            'is_repo': False,
+            'fetch_worked': None,
+            'remote_branch': None,
+            'behind': None,
+            'ahead': None,
+            'tag': None,
+            'branch': None,
+            'dirty': None,
+            'detached': None,
+            'rev': None,
+            'short_rev': None,
+            'url': None,
+        }
         if GitInfo.is_repo(repo_path):
             repo_info["is_repo"] = True
             if fetch:
@@ -1628,9 +1640,9 @@ def get_parser(version) -> argparse.ArgumentParser:
         type=str,
         action="append",
         help="Bazel-style label for the build files into the deppendencies. " +
-             "The format should be `@<workspace>//<path>:BUILD.<dependency-name>.bazel`." + 
+             "The format should be `@<workspace>//<path>:BUILD.<dependency-name>.bazel`." +
              "<dependency-name> should correspond to the name of the dependency in " +
-             "the dependencies.yaml file. This option can be used multiple times." + 
+             "the dependencies.yaml file. This option can be used multiple times." +
              "If not provided, Bazel will search for BUILD file in the repo itself.",
         required=False)
 

--- a/dependency_manager/src/edm_tool/templates/cpm.jinja
+++ b/dependency_manager/src/edm_tool/templates/cpm.jinja
@@ -52,7 +52,7 @@ endif()
 {% endfor %}
 
 execute_process(
-    COMMAND edm release --everest-core-dir ${PROJECT_SOURCE_DIR} --build-dir ${CMAKE_BINARY_DIR} --out ${CMAKE_BINARY_DIR}/release.json
+    COMMAND "${EVEREST_DEPENDENCY_MANAGER}" release --everest-core-dir ${PROJECT_SOURCE_DIR} --build-dir ${CMAKE_BINARY_DIR} --out ${CMAKE_BINARY_DIR}/release.json
 )
 
 install(


### PR DESCRIPTION
fix: get_git_repo_info result dictionary missing entries on error
fix: bump version

Errors obtaining git information were triggering a KeyError exception and hence failing to generate release.json
```
Traceback (most recent call last):
  File "/home/james/venv/bin/edm", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/james/venv/lib/python3.12/site-packages/edm_tool/__init__.py", line 17, in main
    edm.main(get_parser())
  File "/home/james/venv/lib/python3.12/site-packages/edm_tool/edm.py", line 1667, in main
    args.action_handler(args)
  File "/home/james/venv/lib/python3.12/site-packages/edm_tool/edm.py", line 1301, in release_handler
    if everest_core_repo_info["rev"]:
       ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^
KeyError: 'rev'
```