### PR TITLE
Add warning for non-amd64-platforms

### DIFF
--- a/.github/workflows/deploy-docker-images.yml
+++ b/.github/workflows/deploy-docker-images.yml
@@ -13,6 +13,7 @@ env:
   DOCKER_DIRECTORY: docker/images
   PLATFORMS: |
     linux/amd64
+    linux/arm64
   PATH_TO_DEPLOY_DOCKER_IMAGES_WORKFLOW: .github/workflows/deploy-docker-images.yml
 
 jobs:

--- a/docker/images/mosquitto/Dockerfile
+++ b/docker/images/mosquitto/Dockerfile
@@ -1,3 +1,15 @@
 FROM eclipse-mosquitto:2.0.10
 
 COPY mosquitto.conf /mosquitto/config/mosquitto.conf
+
+ARG TARGETARCH
+COPY entrypoint_wrapper.sh /entrypoint_wrapper.sh
+RUN if [ ${TARGETARCH} != "amd64" ]; then \
+        mv /docker-entrypoint.sh /wrapped_entrypoint.sh; \
+        cp /entrypoint_wrapper.sh /entrypoint.sh; \
+    else \
+        mv /docker-entrypoint.sh /entrypoint.sh; \
+    fi; \
+    rm /entrypoint_wrapper.sh
+ENTRYPOINT [ "/entrypoint.sh" ]
+CMD ["/usr/sbin/mosquitto", "-c", "/mosquitto/config/mosquitto.conf"]

--- a/docker/images/mosquitto/entrypoint_wrapper.sh
+++ b/docker/images/mosquitto/entrypoint_wrapper.sh
@@ -1,0 +1,37 @@
+#!/bin/ash
+
+# ---------------------------------------------
+# Architecture Warning Wrapper Script
+#
+# This script is used as an entrypoint wrapper to emit a warning
+# when the container is not running on the officially supported
+# amd64 (x86_64) architecture.
+#
+# It checks for the presence of a wrapped entrypoint script
+# (/wrapped_entrypoint.sh) and executes it if found; otherwise,
+# it falls back to executing the provided command directly.
+#
+# The warning is shown both before and after the wrapped command
+# to ensure visibility.
+# ---------------------------------------------
+
+function print_warning {
+    echo -e "\033[0;31m"
+    echo "-------------------------------------------------------------"
+    echo "⚠️  WARNING: Unsupported Architecture Detected"
+    echo
+    echo "This Docker image is not running on the amd64 (x86_64) architecture."
+    echo "It is recommended to use the amd64-based image for full compatibility."
+    echo "Other architectures are not officially supported and may cause issues."
+    echo
+    echo "-------------------------------------------------------------"
+    echo -e "\033[0m"
+}
+
+print_warning
+
+if [ -f /wrapped_entrypoint.sh ]; then
+    exec /wrapped_entrypoint.sh "$@"
+else
+    exec "$@"
+fi

--- a/docker/images/mqtt-explorer/Dockerfile
+++ b/docker/images/mqtt-explorer/Dockerfile
@@ -1,3 +1,19 @@
 FROM smeagolworms4/mqtt-explorer:browser-1.0.3
 
 COPY ./settings.json /mqtt-explorer/config/settings.json
+
+ARG TARGETARCH
+COPY entrypoint_wrapper.sh /entrypoint_wrapper.sh
+RUN if [ ${TARGETARCH} != "amd64" ]; then \
+        mv /entrypoint.sh /wrapped_entrypoint.sh; \
+        cp /entrypoint_wrapper.sh /entrypoint.sh; \
+    fi; \
+    rm /entrypoint_wrapper.sh
+ENTRYPOINT [ "/entrypoint.sh" ]
+CMD node node-server/server/dist/node-server/server/src/index.js \
+   --http-port=$HTTP_PORT \
+   --config-path=$CONFIG_PATH \
+   --http-user=$HTTP_USER \
+   --http-password=$HTTP_PASSWORD\
+   --ssl-key-path=$SSL_KEY_PATH\
+   --ssl-cert-path=$SSL_CERT_PATH

--- a/docker/images/mqtt-explorer/entrypoint_wrapper.sh
+++ b/docker/images/mqtt-explorer/entrypoint_wrapper.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+# ---------------------------------------------
+# Architecture Warning Wrapper Script
+#
+# This script is used as an entrypoint wrapper to emit a warning
+# when the container is not running on the officially supported
+# amd64 (x86_64) architecture.
+#
+# It checks for the presence of a wrapped entrypoint script
+# (/wrapped_entrypoint.sh) and executes it if found; otherwise,
+# it falls back to executing the provided command directly.
+#
+# The warning is shown both before and after the wrapped command
+# to ensure visibility.
+# ---------------------------------------------
+
+function print_warning {
+    echo -e "\033[0;31m"
+    echo "-------------------------------------------------------------"
+    echo "⚠️  WARNING: Unsupported Architecture Detected"
+    echo
+    echo "This Docker image is not running on the amd64 (x86_64) architecture."
+    echo "It is recommended to use the amd64-based image for full compatibility."
+    echo "Other architectures are not officially supported and may cause issues."
+    echo
+    echo "-------------------------------------------------------------"
+    echo -e "\033[0m"
+}
+
+print_warning
+
+if [ -f /wrapped_entrypoint.sh ]; then
+    exec /wrapped_entrypoint.sh "$@"
+else
+    exec "$@"
+fi

--- a/docker/images/nodered/Dockerfile
+++ b/docker/images/nodered/Dockerfile
@@ -3,3 +3,15 @@ RUN npm install node-red-dashboard@3.6.5
 RUN npm install node-red-contrib-ui-actions@0.1.8
 RUN npm install node-red-node-ui-table@0.4.3
 RUN npm install node-red-contrib-ui-level@0.1.46
+
+USER root
+COPY entrypoint.sh /entrypoint.sh
+ARG TARGETARCH
+COPY entrypoint_wrapper.sh /entrypoint_wrapper.sh
+RUN if [ ${TARGETARCH} != "amd64" ]; then \
+        mv /entrypoint.sh /wrapped_entrypoint.sh; \
+        cp /entrypoint_wrapper.sh /entrypoint.sh; \
+    fi; \
+    rm /entrypoint_wrapper.sh
+USER node-red
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/docker/images/nodered/entrypoint.sh
+++ b/docker/images/nodered/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+exec npm \
+    --no-update-notifier \
+    --no-fund \
+    start \
+    --cache /data/.npm \
+    -- \
+    --userDir /data \
+    "$@"

--- a/docker/images/nodered/entrypoint_wrapper.sh
+++ b/docker/images/nodered/entrypoint_wrapper.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+# ---------------------------------------------
+# Architecture Warning Wrapper Script
+#
+# This script is used as an entrypoint wrapper to emit a warning
+# when the container is not running on the officially supported
+# amd64 (x86_64) architecture.
+#
+# It checks for the presence of a wrapped entrypoint script
+# (/wrapped_entrypoint.sh) and executes it if found; otherwise,
+# it falls back to executing the provided command directly.
+#
+# The warning is shown both before and after the wrapped command
+# to ensure visibility.
+# ---------------------------------------------
+
+function print_warning {
+    echo -e "\033[0;31m"
+    echo "-------------------------------------------------------------"
+    echo "⚠️  WARNING: Unsupported Architecture Detected"
+    echo
+    echo "This Docker image is not running on the amd64 (x86_64) architecture."
+    echo "It is recommended to use the amd64-based image for full compatibility."
+    echo "Other architectures are not officially supported and may cause issues."
+    echo
+    echo "-------------------------------------------------------------"
+    echo -e "\033[0m"
+}
+
+print_warning
+
+if [ -f /wrapped_entrypoint.sh ]; then
+    exec /wrapped_entrypoint.sh "$@"
+else
+    exec "$@"
+fi

--- a/docker/images/steve/Dockerfile
+++ b/docker/images/steve/Dockerfile
@@ -14,4 +14,17 @@ COPY main.properties src/main/resources/config/docker
 COPY init.sh .
 COPY keystore.jks .
 
+ARG TARGETARCH
+COPY entrypoint_wrapper.sh /entrypoint_wrapper.sh
+RUN if [ ${TARGETARCH} != "amd64" ]; then \
+        ln -s /usr/local/bin/mvn-entrypoint.sh /wrapped_entrypoint.sh; \
+        cp /entrypoint_wrapper.sh /entrypoint.sh; \
+    else \
+        ln -s /usr/local/bin/mvn-entrypoint.sh /entrypoint.sh; \
+    fi; \
+    rm /entrypoint_wrapper.sh
+ENTRYPOINT [ "/entrypoint.sh" ]
 CMD /steve/init.sh
+
+
+

--- a/docker/images/steve/entrypoint_wrapper.sh
+++ b/docker/images/steve/entrypoint_wrapper.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# ---------------------------------------------
+# Architecture Warning Wrapper Script
+#
+# This script is used as an entrypoint wrapper to emit a warning
+# when the container is not running on the officially supported
+# amd64 (x86_64) architecture.
+#
+# It checks for the presence of a wrapped entrypoint script
+# (/wrapped_entrypoint.sh) and executes it if found; otherwise,
+# it falls back to executing the provided command directly.
+#
+# The warning is shown both before and after the wrapped command
+# to ensure visibility.
+# ---------------------------------------------
+
+function print_warning {
+    echo -e "\033[0;31m"
+    echo "-------------------------------------------------------------"
+    echo "⚠️  WARNING: Unsupported Architecture Detected"
+    echo
+    echo "This Docker image is not running on the amd64 (x86_64) architecture."
+    echo "It is recommended to use the amd64-based image for full compatibility."
+    echo "Other architectures are not officially supported and may cause issues."
+    echo
+    echo "-------------------------------------------------------------"
+    echo -e "\033[0m"
+}
+
+print_warning
+
+if [ -f /wrapped_entrypoint.sh ]; then
+    exec /wrapped_entrypoint.sh "$@"
+else
+    exec "$@"
+fi


### PR DESCRIPTION
Add entrypoint_wrapper.sh for each docker image that becomes wrapped arround original entrypoint dependent from platform