### PR TITLE
Implement mechanism to (partially) replace dependency git URLs

### DIFF
--- a/dependency_manager/README.md
+++ b/dependency_manager/README.md
@@ -127,16 +127,16 @@ Here *cmake_condition* can be any string that CMake can use in an if() block. Pl
 To change dependency git URLs you can set the *EVEREST_MODIFY_DEPENDENCIES_URLS* environment variable to a string containing prefixes and replacements delimited by whitespace characters.
 For example:
 ```bash
-EVEREST_MODIFY_DEPENDENCIES_URLS="prefix=git@github.com:EVerest/ replace=https://github.com/EVerest/"
+EVEREST_MODIFY_DEPENDENCIES_URLS="prefix=https://github.com/EVerest/ replace=git@github.com:EVerest/"
 ```
-This would change all dependency git URLs that start with *git@github.com:EVerest/* to *https://github.com/EVerest/*.
+This would change all dependency git URLs that start with *https://github.com/EVerest/* to *git@github.com:EVerest/*.
 
 Multiple prefix and replace pairs can be chained together delimited by whitespace characters.
 For example:
 ```bash
-EVEREST_MODIFY_DEPENDENCIES_URLS="prefix=git@github.com:EVerest/ replace=https://github.com/EVerest/ prefix=https://github.com/EVerest/everest-framework.git replace=git@github.com:EVerest/everest-framework.git"
+EVEREST_MODIFY_DEPENDENCIES_URLS="prefix=https://github.com/EVerest/ replace=git@github.com:EVerest/ prefix=https://github.com/EVerest/everest-framework.git replace=https://github.com/EVerest/everest-framework.git"
 ```
-This would change all dependency git URLs that start with *git@github.com:EVerest/* to *https://github.com/EVerest/* as well as change the dependency git URL of *https://github.com/EVerest/everest-framework.git* to *git@github.com:EVerest/everest-framework.git* .
+This would change all dependency git URLs that start with *https://github.com/EVerest/* to *git@github.com:EVerest/* as well as keeping the dependency https URL of *https://github.com/EVerest/everest-framework.git* as *https://github.com/EVerest/everest-framework.git*.
 
 Additionally you can set the *EVEREST_MODIFY_DEPENDENCIES* environment variable to a file containing modifications to the projects dependencies.yaml files when running cmake:
 

--- a/dependency_manager/README.md
+++ b/dependency_manager/README.md
@@ -9,6 +9,7 @@
   - [Setting up a workspace](#setting-up-a-workspace)
   - [Updating a workspace](#updating-a-workspace)
   - [Using the EDM CMake module and dependencies.yaml](#using-the-edm-cmake-module-and-dependenciesyaml)
+  - [Modifying dependencies](#modifying-dependencies)
   - [Create a workspace config from an existing directory tree](#create-a-workspace-config-from-an-existing-directory-tree)
   - [Git information at a glance](#git-information-at-a-glance)
 
@@ -120,6 +121,15 @@ catch2:
 
 ```
 Here *cmake_condition* can be any string that CMake can use in an if() block. Please be aware that any variables you use here must be defined before a call to *evc_setup_edm()* is made in your CMakeLists.txt
+
+## Modifying dependencies
+
+To change dependency git URLs you can set the *EVEREST_MODIFY_DEPENDENCIES_URLS* environment variable to a string containing prefixes and replacements delimited by whitespace characters.
+For example:
+```bash
+EVEREST_MODIFY_DEPENDENCIES_URLS="prefix=git@github.com:EVerest/ replace=https://github.com/EVerest/"
+```
+This would change all dependency git URLs that start with *git@github.com:EVerest/* to *https://github.com/EVerest/*.
 
 Additionally you can set the *EVEREST_MODIFY_DEPENDENCIES* environment variable to a file containing modifications to the projects dependencies.yaml files when running cmake:
 

--- a/dependency_manager/README.md
+++ b/dependency_manager/README.md
@@ -131,6 +131,13 @@ EVEREST_MODIFY_DEPENDENCIES_URLS="prefix=git@github.com:EVerest/ replace=https:/
 ```
 This would change all dependency git URLs that start with *git@github.com:EVerest/* to *https://github.com/EVerest/*.
 
+Multiple prefix and replace pairs can be chained together delimited by whitespace characters.
+For example:
+```bash
+EVEREST_MODIFY_DEPENDENCIES_URLS="prefix=git@github.com:EVerest/ replace=https://github.com/EVerest/ prefix=https://github.com/EVerest/everest-framework.git replace=git@github.com:EVerest/everest-framework.git"
+```
+This would change all dependency git URLs that start with *git@github.com:EVerest/* to *https://github.com/EVerest/* as well as change the dependency git URL of *https://github.com/EVerest/everest-framework.git* to *git@github.com:EVerest/everest-framework.git* .
+
 Additionally you can set the *EVEREST_MODIFY_DEPENDENCIES* environment variable to a file containing modifications to the projects dependencies.yaml files when running cmake:
 
 ```bash

--- a/dependency_manager/src/edm_tool/__init__.py
+++ b/dependency_manager/src/edm_tool/__init__.py
@@ -5,7 +5,7 @@
 """Everest Dependency Manager."""
 from edm_tool import edm
 
-__version__ = "0.7.2"
+__version__ = "0.8.0"
 
 
 def get_parser():

--- a/dependency_manager/src/edm_tool/edm.py
+++ b/dependency_manager/src/edm_tool/edm.py
@@ -1510,14 +1510,14 @@ def main_handler(args):
     workspace = EDM.parse_workspace_directory(workspace_dir)
     checkout = EDM.checkout_local_dependencies(workspace, args.workspace, dependencies)
 
-    # modify dependencies from environment variables
+    # Apply modifications from environment variables to the dependencies
 
-    # modify dependencies urls
+    # Apply URL modifications to the dependencies
     env_modify_dependencies_urls = os.environ.get('EVEREST_MODIFY_DEPENDENCIES_URLS')
     if env_modify_dependencies_urls:
         modify_dependencies_urls(dependencies, env_modify_dependencies_urls)
 
-    # modify whole dependency entries
+    # Apply modifications of whole dependency entries, comming from an additional file
     env_modify_dependencies = os.environ.get('EVEREST_MODIFY_DEPENDENCIES')
     if env_modify_dependencies:
         modify_dependencies_file = Path(env_modify_dependencies).expanduser().resolve()


### PR DESCRIPTION
This can be achieved by setting the EVEREST_MODIFY_DEPENDENCIES_URLS environment variable to pairs of prefix= and replace= entries delimited by whitespace characters.