### PR TITLE
Refactor command line arguments and defaults

### DIFF
--- a/everest_dev_tool/src/everest_dev_tool/git_handlers.py
+++ b/everest_dev_tool/src/everest_dev_tool/git_handlers.py
@@ -4,9 +4,17 @@ import subprocess
 
 default_logger = logging.getLogger("EVerest's Development Tool - Git Helpers")
 
-def clone_handler(args: argparse.Namespace, log: logging.Logger = default_logger):
-    log.debug("Running clone handler")
+def clone_handler(args: argparse.Namespace):
+    log = args.logger
 
+    log.info(
+        f"Cloning repository:\n"
+        f"  Method: {args.method}\n"
+        f"  Forge: {args.forge}\n"
+        f"  Organization: {args.organization}\n"
+        f"  Repository Name: {args.repository_name}\n"
+        f"  Branch: {args.branch}\n"
+    )
     repository_url = ""
     if args.method == 'https':
         repository_url = f"https://{args.forge}/"
@@ -14,4 +22,11 @@ def clone_handler(args: argparse.Namespace, log: logging.Logger = default_logger
         repository_url = f"git@{args.forge}:"
     repository_url = repository_url + f"{ args.organization }/{ args.repository_name }.git"
 
-    subprocess.run(["git", "clone", "-b", args.branch, repository_url], check=True)
+    cmd_args = ["git", "clone", "-b", args.branch, repository_url]
+
+    log.debug(f"Command to execute: {' '.join(cmd_args)}")
+
+    if args.dry:
+        log.info(f"Dry run: Would execute: {' '.join(cmd_args)}")
+    else:
+        subprocess.run(cmd_args, check=True)

--- a/everest_dev_tool/src/everest_dev_tool/git_handlers.py
+++ b/everest_dev_tool/src/everest_dev_tool/git_handlers.py
@@ -7,10 +7,11 @@ default_logger = logging.getLogger("EVerest's Development Tool - Git Helpers")
 def clone_handler(args: argparse.Namespace, log: logging.Logger = default_logger):
     log.debug("Running clone handler")
 
-    if args.https:
-        repository_url = "https://github.com/"
+    repository_url = ""
+    if args.method == 'https':
+        repository_url = f"https://{args.forge}/"
     else:
-        repository_url = "git@github.com:"
+        repository_url = f"git@{args.forge}:"
     repository_url = repository_url + f"{ args.organization }/{ args.repository_name }.git"
 
     subprocess.run(["git", "clone", "-b", args.branch, repository_url], check=True)

--- a/everest_dev_tool/src/everest_dev_tool/parser.py
+++ b/everest_dev_tool/src/everest_dev_tool/parser.py
@@ -1,5 +1,6 @@
 import argparse
 import logging
+import os
 
 from . import services, git_handlers
 
@@ -40,9 +41,38 @@ def get_parser(version: str) -> argparse.ArgumentParser:
     # Git related commands
     clone_parser = subparsers.add_parser("clone", help="Clone a repository", add_help=True)
     clone_parser.add_argument('-v', '--verbose', action='store_true', help="Verbose output")
-    clone_parser.add_argument('--organization', '--org', default="EVerest", help="Github Organization name, default is 'EVerest'")
+    default_git_forge = os.environ.get("EVEREST_DEV_TOOL_DEFAULT_GIT_FORGE", "github.com")
+    clone_parser.add_argument(
+        '--forge',
+        default=default_git_forge,
+        help=(
+            "Git forge to use, default is 'github.com' "
+            "(can be overridden by the environment variable "
+            "EVEREST_DEV_TOOL_DEFAULT_GIT_FORGE)"
+        ),
+    )
+    default_git_method = os.environ.get("EVEREST_DEV_TOOL_DEFAULT_GIT_METHOD", "ssh")
+    clone_parser.add_argument(
+        '--method',
+        default=default_git_method,
+        choices=['https', 'ssh'],
+        help=(
+            "Git method to use, default is 'ssh' "
+            "(can be overridden by the environment variable "
+            "EVEREST_DEV_TOOL_DEFAULT_GIT_METHOD)"
+        )
+    )
+    default_git_organization = os.environ.get("EVEREST_DEV_TOOL_DEFAULT_GIT_ORGANIZATION", "EVerest")
+    clone_parser.add_argument(
+        '--organization', '--org',
+        default=default_git_organization,
+        help=(
+            "Github Organization name, default is 'EVerest'"
+            " (can be overridden by the environment variable "
+            "EVEREST_DEV_TOOL_DEFAULT_GIT_ORGANIZATION)"
+        )
+    )
     clone_parser.add_argument('--branch', '-b', default="main", help="Branch to checkout, default is 'main'")
-    clone_parser.add_argument('--https', action='store_true', help="Use HTTPS to clone the repository, default is 'SSH'")
     clone_parser.add_argument("repository_name", help="Name of the repository to clone")
     clone_parser.set_defaults(action_handler=git_handlers.clone_handler)
 

--- a/everest_dev_tool/src/everest_dev_tool/parser.py
+++ b/everest_dev_tool/src/everest_dev_tool/parser.py
@@ -73,6 +73,7 @@ def get_parser(version: str) -> argparse.ArgumentParser:
         )
     )
     clone_parser.add_argument('--branch', '-b', default="main", help="Branch to checkout, default is 'main'")
+    clone_parser.add_argument('--dry', action='store_true', help="Dry run, do not execute the clone command")
     clone_parser.add_argument("repository_name", help="Name of the repository to clone")
     clone_parser.set_defaults(action_handler=git_handlers.clone_handler)
 


### PR DESCRIPTION
Refactor command line arguments and defaults of everest dev tool' clone command:
- The argument '--https' is removed and replaces by '--method {https,ssh}'
- Add argument '--forge' to allow non github.com forges
- Defaults of '--forge', '--method', '--organization' can be overwritten by the env vars 'EVEREST_DEV_TOOL_DEFAULT_GIT_FORGE', 'EVEREST_DEV_TOOL_DEFAULT_GIT_METHOD' and 'EVEREST_DEV_TOOL_DEFAULT_GIT_ORGANIZATION'